### PR TITLE
Fix Claude Code detection on Windows

### DIFF
--- a/src-tauri/src/claude_binary.rs
+++ b/src-tauri/src/claude_binary.rs
@@ -167,19 +167,29 @@ fn discover_system_installations() -> Vec<ClaudeInstallation> {
 /// Try using the 'which' command to find Claude
 fn try_which_command() -> Option<ClaudeInstallation> {
     debug!("Trying 'which claude' to find binary...");
-
-    match Command::new("which").arg("claude").output() {
+    
+    #[cfg(target_os = "windows")]
+    let command_name = "where";
+    #[cfg(not(target_os = "windows"))]
+    let command_name = "which";
+    
+    match Command::new(command_name).arg("claude").output() {
         Ok(output) if output.status.success() => {
             let output_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
             if output_str.is_empty() {
                 return None;
             }
-
-            // Parse aliased output: "claude: aliased to /path/to/claude"
-            let path = if output_str.starts_with("claude:") && output_str.contains("aliased to") {
-                output_str
-                    .split("aliased to")
+            
+            // Parse output based on OS
+            let path = if cfg!(target_os = "windows") {
+                // Windows 'where' returns multiple lines, prefer .cmd
+                output_str.lines()
+                    .find(|line| line.ends_with(".cmd"))
+                    .or_else(|| output_str.lines().next())
+                    .map(|s| s.to_string())
+            } else if output_str.starts_with("claude:") && output_str.contains("aliased to") {
+                // Unix alias format
+                output_str.split("aliased to")
                     .nth(1)
                     .map(|s| s.trim().to_string())
             } else {


### PR DESCRIPTION
## Problem
Claudia fails to detect Claude Code installation on Windows with "Failed to load Claude installations" error, even when Claude is properly installed via npm and accessible from PATH.

## Root Cause
1. Detection code uses Unix `which` command, but Windows uses `where`
2. Windows `where` returns multiple results (both `claude` and `claude.cmd`), while the code expected a single path

## Solution
- Use OS-specific commands: `where` on Windows, `which` on Unix/Mac
- Handle Windows multi-line output by preferring `.cmd` files
- Preserve existing Unix/Mac behavior unchanged

## Changes Made
- Modified `try_which_command()` in `src-tauri/src/claude_binary.rs`
- Added compile-time OS detection using `#[cfg]` attributes
- Added Windows-specific output parsing logic

Fixes #239, #248

## Testing
- Tested on Windows 11 with Claude Code installed via npm
- Claude is now properly detected at `C:\Users\[username]\AppData\Roaming\npm\claude.cmd`
- Needs verification on Mac/Linux to ensure no regression

## Note
This change only affects Windows builds through compile-time conditionals, ensuring Mac/Linux behavior remains exactly as before.